### PR TITLE
feat(todo-app): example for riot docs refactored to guide standard.

### DIFF
--- a/src/todo-app/README.md
+++ b/src/todo-app/README.md
@@ -1,0 +1,32 @@
+# Todo app
+
+## Functionality
+
+Quickly add a todo to a list, and strike them off when you're done.
+
+## Usage
+
+`<todo-app>` supports the following custom tag attributes:
+
+| attribute | type | description
+| --- | --- | ---
+| `title` | String | Name of the todo list.
+| `items` | Array *optional* | List of todo items with `title` (String) and `done` state (Boolean). E.g. `[{ title:'Alpha' }, { title:'Beta', done:true }]`.
+
+## Changes
+
+This module is based on the [`<todo>` example in the RiotJS docs](http://riotjs.com/guide/#example). It's adapted to follow the RiotJS Style Guide rules, by making the following changes:
+
+* Renamed to `todo-app` to be custom element spec compliant.
+* Create `todo-app/` directory with `README.md`.
+* Create `todo-app.tag.html` with code from [riotjs.com/guide/#example](http://riotjs.com/guide/#example).
+* Create `todo-app.css` with styles for tag.
+* Create `todo-app.demo.html` with variations of `todo-app`.
+* Assign `this` to `tag`.
+* Put tag props and methods on top (`tag.add = add;` etc.).
+* Add `tag.text = ""` to explicitely show `text` is available on the tag.
+* Remove "fake ES6 syntax" (`add(e) {}` -> `function add(e) {}`).
+* Remove unused `this.disabled = true`.
+* Default `this.items` to empty list (`[]`) to allow empty todo app.
+* Put HTML attribute values between double quotes (`attr="value"`).
+* Use `todo-app` as namespace for module styles in `todo-app.css`.

--- a/src/todo-app/todo-app.css
+++ b/src/todo-app/todo-app.css
@@ -1,0 +1,3 @@
+todo-app .completed {
+    text-decoration: line-through;
+}

--- a/src/todo-app/todo-app.demo.html
+++ b/src/todo-app/todo-app.demo.html
@@ -1,0 +1,27 @@
+<link rel="stylesheet" href="./todo-app.css">
+<script type="riot/tag" src="./todo-app.tag.html"></script>
+
+<demo aria-label="todo app with title and empty list">
+    <todo-app title="Groceries" />
+</demo>
+
+<demo aria-label="todo app with title and initial items">
+    <todo-app title="Groceries" items="{ [{ title:'Apples' }, { title:'Oranges', done:true }] }" />
+</demo>
+
+<script src="https://cdn.jsdelivr.net/riot/2.3.16/riot+compiler.min.js"></script>
+<script>
+    riot.tag('demo', '<yield/>');
+    riot.mount('demo');
+</script>
+<style>
+    /* add a grey bar with the `aria-label` as demo title */
+    demo:before {
+        content: "Demo: " attr(aria-label);
+        display: block;
+        background: #F3F5F5;
+        padding: .5em;
+        clear: both;
+        margin: .5em 0;
+    }
+</style>

--- a/src/todo-app/todo-app.tag.html
+++ b/src/todo-app/todo-app.tag.html
@@ -1,0 +1,45 @@
+<todo-app>
+
+    <h3>{ opts.title }</h3>
+
+    <ul>
+        <li each="{ item in items }">
+            <label class="{ completed: item.done }">
+                <input type="checkbox" checked="{ item.done }" onclick="{ parent.toggle }">
+                { item.title }
+            </label>
+        </li>
+    </ul>
+
+    <form onsubmit="{ add }">
+        <input name="input" value="{ text }" onkeyup="{ edit }">
+        <button disabled="{ !text }">Add #{ items.length + 1 }</button>
+    </form>
+
+    <script>
+        var tag = this;
+        this.items = opts.items || [];
+        this.text = '';
+        this.add = add;
+        this.edit = edit;
+        this.toggle = toggle;
+
+        function add (e) {
+            if (tag.text.length) {
+                tag.items.push({ title: tag.text });
+                tag.text = tag.input.value = '';
+            }
+        }
+
+        function edit (e) {
+            tag.text = e.target.value;
+        }
+
+        function toggle (e) {
+            var item = e.item.item;
+            item.done = !item.done;
+            return true;
+        }
+    </script>
+
+</todo-app>


### PR DESCRIPTION
incl. tag, demo, styles and readme.
