### PR TITLE
chore(build): compile, bundle and minify tag files using `npm run build`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/dist/
 /node_modules/

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Companion to the [RiotJS Style Guide](https://github.com/voorhoede/riotjs-style-guide).",
   "main": "index.js",
   "scripts": {
+    "build": "npm run build:tags && npm run build:min",
+    "build:tags": "riot --ext tag.html src/ dist/tags.js",
+    "build:min": "uglifyjs dist/tags.js --compress --mangle --output dist/tags.min.js --source-map dist/tags.min.js.map",
     "start": "http-server './src/' -c-1 -o -p 33667",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -18,6 +21,8 @@
   },
   "homepage": "https://github.com/jbmoelker/riotjs-demos#readme",
   "devDependencies": {
-    "http-server": "0.9.0"
+    "http-server": "0.9.0",
+    "riot": "2.3.17",
+    "uglify-js": "2.6.2"
   }
 }


### PR DESCRIPTION
- `npm run build:tags` compiles and bundles tag files to `dist/tags.js`
- `npm run build:min` minifies tags to `dist/tags.min.js` plus sourcemaps.
