### PR TITLE
end-to-end testing of tag files with Nightwatch in Chrome & Firefox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /dist/
 /node_modules/
+/test/reports/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,5 +126,6 @@ After installing dependencies (run `npm install`) the following scripts are avai
 `build:min` | Minify tags bundle to `dist/tags.min.js` plus sourcemap.
 `commit` | Prompts you to fill out your git commit message step-by-step.
 `start` | Starts a server on `http://localhost:33667` ("demos" in T9).
-`test` | Run linter.
+`test` | Run end-to-end tests and lint all tag files.
+`test:e2e` | Test all tag files end-to-end in Chrome and Firefox.
 `test:eslint` | Check all tag files for format and syntax errors.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:min": "uglifyjs dist/tags.js --compress --mangle --output dist/tags.min.js --source-map dist/tags.min.js.map",
     "commit": "git-cz",
     "start": "http-server './src/' -c-1 -o -p 33667",
-    "test": "npm run test:eslint",
+    "test": "npm run test:e2e && npm run test:eslint",
+    "test:e2e": "node test/e2e.js --env chrome,firefox",
     "test:eslint": "eslint src/**/*.tag.html"
   },
   "config": {
@@ -28,12 +29,18 @@
   },
   "homepage": "https://github.com/jbmoelker/riotjs-demos#readme",
   "devDependencies": {
+    "chromedriver": "2.21.2",
     "commitizen": "2.7.6",
     "cz-conventional-changelog": "1.1.5",
     "eslint": "2.5.1",
     "eslint-plugin-html": "1.4.0",
+    "gulp": "3.9.1",
+    "gulp-connect": "3.2.2",
+    "gulp-nightwatch": "0.2.9",
     "http-server": "0.9.0",
     "riot": "2.3.17",
-    "uglify-js": "2.6.2"
+    "selenium-server-standalone-jar": "2.53.0",
+    "uglify-js": "2.6.2",
+    "yargs": "4.6.0"
   }
 }

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -1,0 +1,34 @@
+/**
+ * Starts a test server for the app.
+ * Runs the entire end-to-end (e2e) test suite.
+ * Stops the test server.
+ */
+
+const connect = require('gulp-connect');
+const gulp = require('gulp');
+const nightwatch = require('gulp-nightwatch');
+const yargs = require('yargs');
+
+runTests({
+    configFile: __dirname + '/nightwatch.config.js',
+    cliArgs: yargs.argv
+});
+
+function runTests(config) {
+    startApp();
+    gulp.src('')
+        .pipe(nightwatch(config))
+        .on('end', closeApp)
+        .on('error', closeApp);
+}
+
+function startApp() {
+    connect.server({
+        root: './',
+        port: require('./nightwatch.config').app_port
+    });
+}
+
+function closeApp() {
+    connect.serverClose();
+}

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -19,7 +19,11 @@ function runTests(config) {
     gulp.src('')
         .pipe(nightwatch(config))
         .on('end', closeApp)
-        .on('error', closeApp);
+        .on('error', (err) => {
+            console.error(err);
+            closeApp();
+            process.exit(1);
+        });
 }
 
 function startApp() {

--- a/test/e2e/todo-app.e2e.js
+++ b/test/e2e/todo-app.e2e.js
@@ -1,0 +1,27 @@
+const todo1 = 'demo:nth-child(1) todo-app'; // use to do app in first demo
+
+module.exports = {
+    before: (browser) => browser.url(`${browser.launchUrl}src/todo-app/todo-app.demo.html`),
+    after:  (browser) => browser.end(),
+
+    'Create empty todo list' : (browser) => browser
+        .waitForElementVisible(todo1, 1000)
+        .assert.containsText(todo1, 'Groceries')
+        .assert.elementNotPresent(`${todo1} li`),
+
+    'Add new todo item': (browser) => browser
+        .setValue(`${todo1} input[value="{text}"]`, 'Apples')
+        .click(`${todo1} button`)
+        .assert.containsText(`${todo1} li`, 'Apples')
+        .assert.cssClassNotPresent(`${todo1} label`, 'completed'),
+
+    'Complete the new item': (browser) => browser
+        .click(`${todo1} input[type="checkbox"]`)
+        .assert.cssClassPresent(`${todo1} label`, 'completed')
+        .assert.cssProperty(`${todo1} label`, 'text-decoration', 'line-through'),
+
+    'Restore the new item': (browser) => browser
+        .click(`${todo1} label`) // clicking should work on both checkbox and label
+        .assert.cssClassNotPresent(`${todo1} label`, 'completed')
+        .assert.cssProperty(`${todo1} label`, 'text-decoration', 'none')
+};

--- a/test/nightwatch.config.js
+++ b/test/nightwatch.config.js
@@ -1,0 +1,42 @@
+const APP_PORT = 33668;
+
+module.exports = {
+    app_port: APP_PORT, // expose to external scripts, not used by Nightwatch
+    src_folders: 'test/e2e',
+    //page_objects_path: 'test/models',
+    output_folder: 'test/reports',
+
+    selenium: {
+        start_process: true,
+        server_path: require('selenium-server-standalone-jar').path,
+        log_path: false,
+        host: '127.0.0.1',
+        port: 4444,
+        cli_args: {
+            'webdriver.chrome.driver' : require('chromedriver').path
+        }
+    },
+
+    test_settings: {
+        default : {
+            launch_url: `http://localhost:${APP_PORT}/`,
+            selenium_port: 4444,
+            desiredCapabilities: {
+                browserName: 'chrome',
+                javascriptEnabled: true
+            }
+        },
+        firefox: {
+            desiredCapabilities: {
+                browserName: 'firefox',
+                javascriptEnabled: true
+            }
+        },
+        chrome: {
+            desiredCapabilities: {
+                browserName: 'chrome',
+                javascriptEnabled: true
+            }
+        }
+    }
+};


### PR DESCRIPTION
- Uses `<todo-app>` as example.
- Could be improved with tag models ("page objects" in Nightwatch).
- Travis CI should ~~probably~~ still be configured to run these browsers.
- RiotJS should be served from `node_modules` instead of from CDN.
